### PR TITLE
Fixes errors when accessing missing or unauthorized KB articles

### DIFF
--- a/controller/main_controller.php
+++ b/controller/main_controller.php
@@ -1009,7 +1009,7 @@ class main_controller implements main_interface
 				}
 				$this->db->sql_freeresult($result);
 
-				if ($data['article_visibility'] <> constants::ARTICLE_APPROVED && !$this->auth->acl_get('m_kb_approve'))
+				if (!$data || ($data['article_visibility'] <> constants::ARTICLE_APPROVED && !$this->auth->acl_get('m_kb_approve')))
 				{
 					throw new \phpbb\exception\http_exception(404, $this->lang->lang('KB_NO_ARTICLE'));
 				}


### PR DESCRIPTION
1. If a user without KB release permission calls up an article for which he has no authorization in the context, he does get the correct error message that the article does not exist, but also an array key error.

2. If a user with KB release permission accesses an article that doesn't exist, he doesn't get the controlled error message provided for this, but only a flood of array key errors.

Both scenarios have the same cause and this is due to the changes in PHP 8. Noticed during a Google search, where a KB link to us also went nowhere and caused this error 1.